### PR TITLE
Use find_namespace_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,5 @@ setuptools.setup(
     ext_modules=get_extensions(),
     classifiers=["Programming Language :: Python :: 3", "Operating System :: OS Independent"],
     cmdclass={"build_ext": torch.utils.cpp_extension.BuildExtension},
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_namespace_packages(),
 )


### PR DESCRIPTION
When installed with pip3 install git+https://github.com/ifzhang/ByteTrack i.e., not in develop model, it skips on installing sub-packages without __init__.py file, eg `yolox.tracker`

using `find_namespace_packages` should install yolox.tracker and other sub folders without __init__.py