### PR TITLE
update torchvision to support newer versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ opencv_python
 loguru
 scikit-image
 tqdm
-torchvision==0.10.0
+torchvision>=0.10.0
 Pillow
 thop
 ninja


### PR DESCRIPTION
when building inside newer nvidia pytorch dockers, it downgrades the preinstalled torch and torchvision, since torchvision version is hardcoaded to `0.10.0`
This commit allows newer versions to keep as it.