### PR TITLE
fixed match_thresh data type

### DIFF
--- a/tools/demo_track.py
+++ b/tools/demo_track.py
@@ -79,7 +79,7 @@ def make_parser():
     # tracking args
     parser.add_argument("--track_thresh", type=float, default=0.5, help="tracking confidence threshold")
     parser.add_argument("--track_buffer", type=int, default=30, help="the frames for keep lost tracks")
-    parser.add_argument("--match_thresh", type=int, default=0.8, help="matching threshold for tracking")
+    parser.add_argument("--match_thresh", type=float, default=0.8, help="matching threshold for tracking")
     parser.add_argument('--min-box-area', type=float, default=10, help='filter out tiny boxes')
     parser.add_argument("--mot20", dest="mot20", default=False, action="store_true", help="test mot20.")
     return parser


### PR DESCRIPTION
Fixed the data type of match_thresh, otherwise it will throw data type error if we pass any float value to the script through match_thresh param.
e.g `python3 tools/demo_track.py video -f exps/example/mot/yolox_x_mix_det.py -c pretrained/bytetrack_x_mot17.pth.tar --fp16 --fuse --save_result --match_thresh 0.3`
Throws error  
`ByteTrack Demo!: error: argument --match_thresh: invalid int value: '0.3'`