### PR TITLE
Changed match_thresh data type to float 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 
 ## Abstract
-Multi-object tracking (MOT) aims at estimating bounding boxes and identities of objects in videos. Most methods obtain identities by associating detection boxes whose scores are higher than a threshold. The objects with low detection scores, e.g. occluded objects, are simply thrown away, which brings non-negligible true object missing and fragmented trajectories. To solve this problem, we present a simple, effective and generic association method, tracking by associating every detection box instead of only the high score ones. For the low score detection boxes, we utilize their similarities with tracklets to recover true objects and filter out the background detections. When applied to 9 different state-of-the-art trackers, our method achieves consistent improvement on IDF1 score ranging from 1 to 10 points.To put forwards the state-of-the-art performance of MOT, we design a simple and strong tracker, named ByteTrack. For the first time, we achieve 80.3 MOTA, 77.3 IDF1 and 63.1 HOTA on the test set of MOT17 with 30 FPS running speed on a single V100 GPU.
+Multi-object tracking (MOT) aims at estimating bounding boxes and identities of objects in videos. Most methods obtain identities by associating detection boxes whose scores are higher than a threshold. The objects with low detection scores, e.g. occluded objects, are simply thrown away, which brings non-negligible true object missing and fragmented trajectories. To solve this problem, we present a simple, effective and generic association method, tracking by associating every detection box instead of only the high score ones. For the low score detection boxes, we utilize their similarities with tracklets to recover true objects and filter out the background detections. When applied to 9 different state-of-the-art trackers, our method achieves consistent improvement on IDF1 scores ranging from 1 to 10 points. To put forwards the state-of-the-art performance of MOT, we design a simple and strong tracker, named ByteTrack. For the first time, we achieve 80.3 MOTA, 77.3 IDF1 and 63.1 HOTA on the test set of MOT17 with 30 FPS running speed on a single V100 GPU.
 <p align="center"><img src="assets/teasing.png" width="400"/></p>
 
 ## Tracking performance
@@ -113,7 +113,7 @@ python3 tools/convert_cityperson_to_coco.py
 python3 tools/convert_ethz_to_coco.py
 ```
 
-Before mixing different datasets, you need to following the operations in [mix_xxx.py](https://github.com/ifzhang/ByteTrack/blob/c116dfc746f9ebe07d419caa8acba9b3acfa79a6/tools/mix_data_ablation.py#L6) to create data folder and link. Finally you can mix the training data:
+Before mixing different datasets, you need to follow the operations in [mix_xxx.py](https://github.com/ifzhang/ByteTrack/blob/c116dfc746f9ebe07d419caa8acba9b3acfa79a6/tools/mix_data_ablation.py#L6) to create a data folder and link. Finally, you can mix the training data:
 
 ```shell
 cd <ByteTrack_HOME>
@@ -242,7 +242,7 @@ See [tutorials](https://github.com/ifzhang/ByteTrack/tree/main/tutorials).
 
 ## Combining BYTE with other detectors
 
-Suppose you have already got the detection results 'dets' (x1, y1, x2, y2, score) from other detectors, you can simply pass the detection results to BYTETracker (you need to first modify some post processing code according to the format of your detection results in [byte_tracker.py](https://github.com/ifzhang/ByteTrack/blob/main/yolox/tracker/byte_tracker.py)):
+Suppose you have already got the detection results 'dets' (x1, y1, x2, y2, score) from other detectors, you can simply pass the detection results to BYTETracker (you need to first modify some post-processing code according to the format of your detection results in [byte_tracker.py](https://github.com/ifzhang/ByteTrack/blob/main/yolox/tracker/byte_tracker.py)):
 
 ```
 from yolox.tracker.byte_tracker import BYTETracker

--- a/deploy/ONNXRuntime/onnx_inference.py
+++ b/deploy/ONNXRuntime/onnx_inference.py
@@ -65,7 +65,7 @@ def make_parser():
     # tracking args
     parser.add_argument("--track_thresh", type=float, default=0.5, help="tracking confidence threshold")
     parser.add_argument("--track_buffer", type=int, default=30, help="the frames for keep lost tracks")
-    parser.add_argument("--match_thresh", type=int, default=0.8, help="matching threshold for tracking")
+    parser.add_argument("--match_thresh", type=float, default=0.8, help="matching threshold for tracking")
     parser.add_argument('--min-box-area', type=float, default=10, help='filter out tiny boxes')
     parser.add_argument("--mot20", dest="mot20", default=False, action="store_true", help="test mot20.")
     return parser

--- a/tools/track_deepsort.py
+++ b/tools/track_deepsort.py
@@ -104,7 +104,7 @@ def make_parser():
     # tracking args
     parser.add_argument("--track_thresh", type=float, default=0.5, help="tracking confidence threshold")
     parser.add_argument("--track_buffer", type=int, default=30, help="the frames for keep lost tracks")
-    parser.add_argument("--match_thresh", type=int, default=0.9, help="matching threshold for tracking")
+    parser.add_argument("--match_thresh", type=float, default=0.9, help="matching threshold for tracking")
     parser.add_argument('--min-box-area', type=float, default=100, help='filter out tiny boxes')
     # deepsort args
     parser.add_argument("--model_folder", type=str, default='pretrained/ckpt.t7', help="reid model folder")

--- a/tools/track_motdt.py
+++ b/tools/track_motdt.py
@@ -104,7 +104,7 @@ def make_parser():
     # tracking args
     parser.add_argument("--track_thresh", type=float, default=0.6, help="tracking confidence threshold")
     parser.add_argument("--track_buffer", type=int, default=30, help="the frames for keep lost tracks")
-    parser.add_argument("--match_thresh", type=int, default=0.9, help="matching threshold for tracking")
+    parser.add_argument("--match_thresh", type=float, default=0.9, help="matching threshold for tracking")
     parser.add_argument('--min-box-area', type=float, default=100, help='filter out tiny boxes')
     # deepsort args
     parser.add_argument("--model_folder", type=str, default='pretrained/googlenet_part8_all_xavier_ckpt_56.h5', help="reid model folder")

--- a/tools/track_sort.py
+++ b/tools/track_sort.py
@@ -104,7 +104,7 @@ def make_parser():
     # tracking args
     parser.add_argument("--track_thresh", type=float, default=0.4, help="tracking confidence threshold")
     parser.add_argument("--track_buffer", type=int, default=30, help="the frames for keep lost tracks")
-    parser.add_argument("--match_thresh", type=int, default=0.9, help="matching threshold for tracking")
+    parser.add_argument("--match_thresh", type=float, default=0.9, help="matching threshold for tracking")
     parser.add_argument('--min-box-area', type=float, default=100, help='filter out tiny boxes')
     return parser
 


### PR DESCRIPTION
Changed match_thresh data type to float in 
ByteTrack/tools/track_deepsort.py
ByteTrack/tools/track_motdt.py
ByteTrack/tools/track_sort.py
ByteTrack/deploy/ONNXRuntime/onnx_inference.py
 Previously it was int, which use to throw 
`error: argument --match_thresh: invalid int value: 'X'`, where X is any float value we pass e.g `0.3`