### PR TITLE
Fix giou bug

### DIFF
--- a/yolox/models/losses.py
+++ b/yolox/models/losses.py
@@ -30,7 +30,8 @@ class IOUloss(nn.Module):
 
         en = (tl < br).type(tl.type()).prod(dim=1)
         area_i = torch.prod(br - tl, 1) * en
-        iou = (area_i) / (area_p + area_g - area_i + 1e-16)
+        area_u = area_p + area_g - area_i
+        iou = (area_i) / (area_u + 1e-16)
 
         if self.loss_type == "iou":
             loss = 1 - iou ** 2
@@ -42,7 +43,7 @@ class IOUloss(nn.Module):
                 (pred[:, :2] + pred[:, 2:] / 2), (target[:, :2] + target[:, 2:] / 2)
             )
             area_c = torch.prod(c_br - c_tl, 1)
-            giou = iou - (area_c - area_i) / area_c.clamp(1e-16)
+            giou = iou - (area_c - area_u) / area_c.clamp(1e-16)
             loss = 1 - giou.clamp(min=-1.0, max=1.0)
 
         if self.reduction == "mean":
@@ -77,5 +78,5 @@ def sigmoid_focal_loss(inputs, targets, num_boxes, alpha: float = 0.25, gamma: f
     if alpha >= 0:
         alpha_t = alpha * targets + (1 - alpha) * (1 - targets)
         loss = alpha_t * loss
-    #return loss.mean(0).sum() / num_boxes
+    # return loss.mean(0).sum() / num_boxes
     return loss.sum() / num_boxes


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10502826/149059929-abbe28db-d6b8-4f49-9051-eb9c5422cb12.png)

`giou = iou - (area_c - area_u) / area_c`
not `area_c - area_i`