### PR TITLE
fix FP16 bug of track_id annotation, ReID related

### DIFF
--- a/yolox/core/trainer.py
+++ b/yolox/core/trainer.py
@@ -91,6 +91,8 @@ class Trainer:
         iter_start_time = time.time()
 
         inps, targets = self.prefetcher.next()
+        track_ids = targets[:, :, 5]
+        targets = targets[:, :, :5]
         inps = inps.to(self.data_type)
         targets = targets.to(self.data_type)
         targets.requires_grad = False


### PR DESCRIPTION
When training with FP16, annotations of bbox and track_id named as `targets` will be **set to torch.float16 from torch.float32**.

But actually, track_id annotations will **lose their precision** during this procedure, resulting wrong labels for ReID module.

![tensor FP16](https://user-images.githubusercontent.com/48764451/165520141-3a5bb3a9-e440-4baa-a2c9-410250ba0ed6.png)

So with the wrong labels, ReID module can not be trained normally, getting **extreme low mAP and top-k ranking** in person search benchmarks.

![search wrong label](https://user-images.githubusercontent.com/48764451/165521285-cd875482-24e1-488d-8564-136d3894d5da.png)

After fixing this bug, we can get **normal results**.

![search correct label](https://user-images.githubusercontent.com/48764451/165521414-7d27f29f-e301-47f8-87d1-18bb90f8d619.png)




