### PR TITLE
Change BaseTrack attributes to Object attributes

### DIFF
--- a/yolox/tracker/basetrack.py
+++ b/yolox/tracker/basetrack.py
@@ -10,31 +10,31 @@ class TrackState(object):
 
 
 class BaseTrack(object):
-    _count = 0
+    def __init__(self):
+        self._count = 0
 
-    track_id = 0
-    is_activated = False
-    state = TrackState.New
+        self.track_id = 0
+        self.is_activated = False
+        self.state = TrackState.New
 
-    history = OrderedDict()
-    features = []
-    curr_feature = None
-    score = 0
-    start_frame = 0
-    frame_id = 0
-    time_since_update = 0
+        self.history = OrderedDict()
+        self.features = []
+        self.curr_feature = None
+        self.score = 0
+        self.start_frame = 0
+        self.frame_id = 0
+        self.time_since_update = 0
 
-    # multi-camera
-    location = (np.inf, np.inf)
+        # multi-camera
+        self.location = (np.inf, np.inf)
 
     @property
     def end_frame(self):
         return self.frame_id
 
-    @staticmethod
-    def next_id():
-        BaseTrack._count += 1
-        return BaseTrack._count
+    def next_id(self):
+        self._count += 1
+        return self._count
 
     def activate(self, *args):
         raise NotImplementedError


### PR DESCRIPTION
All the attributes are used after  object initialisation only, so there is no reason to keep them as Class attributes.  
Keeping them as class attributes instead causes #79 

This should fix #79 and should not affect any other part.  
Have checked that we always call `self.next_id()` and never call `BaseTrack.next_id()` i.e., no need for it to be a static method anymore, since all the attributes are now object attributes.

Fixes #79 