### PR TITLE
Update byte_tracker.py

### DIFF
--- a/yolox/tracker/byte_tracker.py
+++ b/yolox/tracker/byte_tracker.py
@@ -13,7 +13,7 @@ from .basetrack import BaseTrack, TrackState
 class STrack(BaseTrack):
     shared_kalman = KalmanFilter()
     def __init__(self, tlwh, score):
-
+        super().__init__()  # BaseTrack init
         # wait activate
         self._tlwh = np.asarray(tlwh, dtype=np.float)
         self.kalman_filter = None


### PR DESCRIPTION
修改STrack class初始化方法，在其初始化方法中，调用父类BaseTrack的初始化方法。修正[bug 210](https://github.com/ifzhang/ByteTrack/issues/210)
Adding base class init function call at the beginning of `__init__` fucntion of class `STrack` to fix [bug 210](https://github.com/ifzhang/ByteTrack/issues/210)