### PR TITLE
Update byte_tracker.py

### DIFF
--- a/yolox/tracker/byte_tracker.py
+++ b/yolox/tracker/byte_tracker.py
@@ -282,6 +282,7 @@ class BYTETracker(object):
         self.lost_stracks.extend(lost_stracks)
         self.lost_stracks = sub_stracks(self.lost_stracks, self.removed_stracks)
         self.removed_stracks.extend(removed_stracks)
+        self.removed_stracks = [track for track in self.removed_stracks if self.frame_id - track.end_frame < 10 * self.max_time_lost]
         self.tracked_stracks, self.lost_stracks = remove_duplicate_stracks(self.tracked_stracks, self.lost_stracks)
         # get scores of lost tracks
         output_stracks = [track for track in self.tracked_stracks if track.is_activated]


### PR DESCRIPTION
Problem with ByteTracker during long running process.  Virtual memory is consumed in same manner as memory leak.  This is due to the self.removed_stracks list member variable growing without bound.  The issue may be fixed by removing stale tracks from the self.removed_stracks list.  A limit is placed such that tracks older that 10 * self.max_time_lost are removed from the self.removed_stracks list.  This change had no discernible effect on the algorithm.