### PR TITLE
Keep track of detection index

### DIFF
--- a/yolox/tracker/byte_tracker.py
+++ b/yolox/tracker/byte_tracker.py
@@ -12,7 +12,14 @@ from .basetrack import BaseTrack, TrackState
 
 class STrack(BaseTrack):
     shared_kalman = KalmanFilter()
-    def __init__(self, tlwh, score, det_idx=0):
+    def __init__(self, tlwh, score, det_idx=None):
+        """
+        Initialize a tracklet
+        Args:
+            tlwh: (np.ndarray) bbox in format x1,y1,x2,y2
+            score: (float) bbox detection score
+            det_idx: (int) (Optional) corresponding index in object detection list
+        """
 
         # wait activate
         self._tlwh = np.asarray(tlwh, dtype=np.float)
@@ -69,7 +76,6 @@ class STrack(BaseTrack):
         if new_id:
             self.track_id = self.next_id()
         self.score = new_track.score
-        # TODO: handle det_idx does not exist
         self.det_idx = new_track.det_idx
         
     def update(self, new_track, frame_id):
@@ -91,7 +97,6 @@ class STrack(BaseTrack):
 
         self.score = new_track.score
 
-        # TODO: handle det_idx does not exist
         self.det_idx = new_track.det_idx
 
     @property
@@ -164,6 +169,14 @@ class BYTETracker(object):
         self.kalman_filter = KalmanFilter()
 
     def update(self, output_results, img_info, img_size, track_det_idx=False):
+        """
+        Update tracker with detection results
+        Args:
+            output_results: detection results + Scores + det_idx (optional)
+            img_info: original image information
+            img_size: scaled image size
+            track_det_idx: whether to track det_idx (index corresponding to the detection results)
+        """
         self.frame_id += 1
         activated_starcks = []
         refind_stracks = []

--- a/yolox/tracker/byte_tracker.py
+++ b/yolox/tracker/byte_tracker.py
@@ -158,7 +158,7 @@ class BYTETracker(object):
         self.max_time_lost = self.buffer_size
         self.kalman_filter = KalmanFilter()
 
-    def update(self, output_results, img_info, img_size, det_idxs=None):
+    def update(self, output_results, img_info, img_size):
         self.frame_id += 1
         activated_starcks = []
         refind_stracks = []
@@ -171,7 +171,7 @@ class BYTETracker(object):
         elif output_results.shape[1] == 6:
             scores = output_results[:, 4] 
             bboxes = output_results[:, :4]  # x1y1x2y2
-            det_idxs = output_results[:, 5]
+            _det_idxs = output_results[:, 5]
         else:
             output_results = output_results.cpu().numpy()
             scores = output_results[:, 4] * output_results[:, 5]
@@ -189,8 +189,8 @@ class BYTETracker(object):
         dets = bboxes[remain_inds]
         scores_keep = scores[remain_inds]
         scores_second = scores[inds_second]
-        det_idxs = det_idxs[remain_inds]
-        det_idxs_second = det_idxs[inds_second]
+        det_idxs = _det_idxs[remain_inds]
+        det_idxs_second = _det_idxs[inds_second]
 
         if len(dets) > 0:
             '''Detections'''

--- a/yolox/tracker/byte_tracker.py
+++ b/yolox/tracker/byte_tracker.py
@@ -174,7 +174,7 @@ class BYTETracker(object):
         Args:
             output_results: detection results + Scores + det_idx (optional)
             img_info: original image information
-            img_size: scaled image size
+            img_size: inference scaled image size
             track_det_idx: whether to track det_idx (index corresponding to the detection results)
         """
         self.frame_id += 1


### PR DESCRIPTION
Addresses #195 and [unanswered question](https://github.com/ifzhang/ByteTrack/issues/5#issuecomment-966831946) in #5: 
Currently, after updating ByteTrack object, some of the bounding boxes will be dropped, and it's not possible to figure out the original bounding box index form the tracker. For example
```python
boxes, scores, classes, .... = some_detection_model.inference(frame)
boxes_scores = np.concatenate([boxes, scores.reshape(-1,1), ], axis=1)
# In this step len(online_targets) <= len(boxes)
online_targets = tracker.update(boxes_scores, [frame.shape[0], frame.shape[1]], [frame.shape[0], frame.shape[1]])
# Since we are missing some of the boxes, there is no way figuring out relevant information of the boxes like class.
# I did bbox matching method to figure out the original index, but that's inefficient (N^2) 
```

With the solution in this PR you can track index directly using `tracker.update(..., track_det_idx=True)`:
```python
boxes, scores, classes, .... = some_detection_model.inference(image)
det_idxs_orig = np.array(list(range(post_boxes.shape[0]))).reshape(-1,1)
boxes_scores = np.concatenate([boxes, scores.reshape(-1,1), det_idxs_orig], axis=1)
online_targets = tracker.update(boxes_scores, [frame.shape[0], frame.shape[1]], [frame.shape[0], frame.shape[1]], track_det_idx=True)

for track_i, an_online_target in enumerate(online_targets):
            track_xyxy = utils.tlwh_to_xyxy(an_online_target.tlwh)
            det_i = an_online_target.det_idx
            tracked_obj_class = classes[int(det_i)]
```