### PR TITLE
Replace np.<type alias> with base types

### DIFF
--- a/tutorials/centertrack/byte_tracker.py
+++ b/tutorials/centertrack/byte_tracker.py
@@ -15,7 +15,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/centertrack/mot_online/matching.py
+++ b/tutorials/centertrack/mot_online/matching.py
@@ -69,13 +69,13 @@ def ious(atlbrs, btlbrs):
 
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=float)
     if ious.size == 0:
         return ious
 
     ious = bbox_ious(
-        np.ascontiguousarray(atlbrs, dtype=np.float),
-        np.ascontiguousarray(btlbrs, dtype=np.float)
+        np.ascontiguousarray(atlbrs, dtype=float),
+        np.ascontiguousarray(btlbrs, dtype=float)
     )
 
     return ious
@@ -109,13 +109,13 @@ def embedding_distance(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
     #for i, track in enumerate(tracks):
         #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     return cost_matrix
 
@@ -127,17 +127,17 @@ def embedding_distance2(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
     #for i, track in enumerate(tracks):
         #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
-    track_features = np.asarray([track.features[0] for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.features[0] for track in tracks], dtype=float)
     cost_matrix2 = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
-    track_features = np.asarray([track.features[len(track.features)-1] for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.features[len(track.features)-1] for track in tracks], dtype=float)
     cost_matrix3 = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     for row in range(len(cost_matrix)):
         cost_matrix[row] = (cost_matrix[row]+cost_matrix2[row]+cost_matrix3[row])/3
@@ -149,11 +149,11 @@ def vis_id_feature_A_distance(tracks, detections, metric='cosine'):
     det_features = []
     leg1 = len(tracks)
     leg2 = len(detections)
-    cost_matrix = np.zeros((leg1, leg2), dtype=np.float)
-    cost_matrix_det = np.zeros((leg1, leg2), dtype=np.float)
-    cost_matrix_track = np.zeros((leg1, leg2), dtype=np.float)
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    cost_matrix = np.zeros((leg1, leg2), dtype=float)
+    cost_matrix_det = np.zeros((leg1, leg2), dtype=float)
+    cost_matrix_track = np.zeros((leg1, leg2), dtype=float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     if leg2 != 0:
         cost_matrix_det = np.maximum(0.0, cdist(det_features, det_features, metric))
     if leg1 != 0:
@@ -167,8 +167,8 @@ def vis_id_feature_A_distance(tracks, detections, metric='cosine'):
     if leg2 > 10:
         leg2 = 10
         detections = detections[:10]
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     return track_features, det_features, cost_matrix, cost_matrix_det, cost_matrix_track
 
 def gate_cost_matrix(kf, cost_matrix, tracks, detections, only_position=False):

--- a/tutorials/cstrack/byte_tracker.py
+++ b/tutorials/cstrack/byte_tracker.py
@@ -23,7 +23,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/cstrack/tracker.py
+++ b/tutorials/cstrack/tracker.py
@@ -23,7 +23,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score, temp_feat, buffer_size=30):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/ctracker/byte_tracker.py
+++ b/tutorials/ctracker/byte_tracker.py
@@ -17,7 +17,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/ctracker/mot_online/matching.py
+++ b/tutorials/ctracker/mot_online/matching.py
@@ -69,13 +69,13 @@ def ious(atlbrs, btlbrs):
 
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=float)
     if ious.size == 0:
         return ious
 
     ious = bbox_ious(
-        np.ascontiguousarray(atlbrs, dtype=np.float),
-        np.ascontiguousarray(btlbrs, dtype=np.float)
+        np.ascontiguousarray(atlbrs, dtype=float),
+        np.ascontiguousarray(btlbrs, dtype=float)
     )
 
     return ious
@@ -109,13 +109,13 @@ def embedding_distance(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
     #for i, track in enumerate(tracks):
         #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     return cost_matrix
 
@@ -127,17 +127,17 @@ def embedding_distance2(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
     #for i, track in enumerate(tracks):
         #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
-    track_features = np.asarray([track.features[0] for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.features[0] for track in tracks], dtype=float)
     cost_matrix2 = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
-    track_features = np.asarray([track.features[len(track.features)-1] for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.features[len(track.features)-1] for track in tracks], dtype=float)
     cost_matrix3 = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     for row in range(len(cost_matrix)):
         cost_matrix[row] = (cost_matrix[row]+cost_matrix2[row]+cost_matrix3[row])/3
@@ -149,11 +149,11 @@ def vis_id_feature_A_distance(tracks, detections, metric='cosine'):
     det_features = []
     leg1 = len(tracks)
     leg2 = len(detections)
-    cost_matrix = np.zeros((leg1, leg2), dtype=np.float)
-    cost_matrix_det = np.zeros((leg1, leg2), dtype=np.float)
-    cost_matrix_track = np.zeros((leg1, leg2), dtype=np.float)
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    cost_matrix = np.zeros((leg1, leg2), dtype=float)
+    cost_matrix_det = np.zeros((leg1, leg2), dtype=float)
+    cost_matrix_track = np.zeros((leg1, leg2), dtype=float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     if leg2 != 0:
         cost_matrix_det = np.maximum(0.0, cdist(det_features, det_features, metric))
     if leg1 != 0:
@@ -167,8 +167,8 @@ def vis_id_feature_A_distance(tracks, detections, metric='cosine'):
     if leg2 > 10:
         leg2 = 10
         detections = detections[:10]
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     return track_features, det_features, cost_matrix, cost_matrix_det, cost_matrix_track
 
 def gate_cost_matrix(kf, cost_matrix, tracks, detections, only_position=False):

--- a/tutorials/fairmot/byte_tracker.py
+++ b/tutorials/fairmot/byte_tracker.py
@@ -25,7 +25,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/fairmot/tracker.py
+++ b/tutorials/fairmot/tracker.py
@@ -25,7 +25,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score, temp_feat, buffer_size=30):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/jde/byte_tracker.py
+++ b/tutorials/jde/byte_tracker.py
@@ -13,7 +13,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/jde/tracker.py
+++ b/tutorials/jde/tracker.py
@@ -14,7 +14,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score, temp_feat, buffer_size=30):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/motr/byte_tracker.py
+++ b/tutorials/motr/byte_tracker.py
@@ -17,7 +17,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/motr/mot_online/matching.py
+++ b/tutorials/motr/mot_online/matching.py
@@ -68,13 +68,13 @@ def ious(atlbrs, btlbrs):
     :type atlbrs: list[tlbr] | np.ndarray
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=float)
     if ious.size == 0:
         return ious
 
     ious = bbox_ious(
-        np.ascontiguousarray(atlbrs, dtype=np.float),
-        np.ascontiguousarray(btlbrs, dtype=np.float)
+        np.ascontiguousarray(atlbrs, dtype=float),
+        np.ascontiguousarray(btlbrs, dtype=float)
     )
 
     return ious
@@ -107,13 +107,13 @@ def embedding_distance(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
     #for i, track in enumerate(tracks):
         #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     return cost_matrix
 
@@ -125,17 +125,17 @@ def embedding_distance2(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
     #for i, track in enumerate(tracks):
         #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
-    track_features = np.asarray([track.features[0] for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.features[0] for track in tracks], dtype=float)
     cost_matrix2 = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
-    track_features = np.asarray([track.features[len(track.features)-1] for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.features[len(track.features)-1] for track in tracks], dtype=float)
     cost_matrix3 = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     for row in range(len(cost_matrix)):
         cost_matrix[row] = (cost_matrix[row]+cost_matrix2[row]+cost_matrix3[row])/3
@@ -147,11 +147,11 @@ def vis_id_feature_A_distance(tracks, detections, metric='cosine'):
     det_features = []
     leg1 = len(tracks)
     leg2 = len(detections)
-    cost_matrix = np.zeros((leg1, leg2), dtype=np.float)
-    cost_matrix_det = np.zeros((leg1, leg2), dtype=np.float)
-    cost_matrix_track = np.zeros((leg1, leg2), dtype=np.float)
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    cost_matrix = np.zeros((leg1, leg2), dtype=float)
+    cost_matrix_det = np.zeros((leg1, leg2), dtype=float)
+    cost_matrix_track = np.zeros((leg1, leg2), dtype=float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     if leg2 != 0:
         cost_matrix_det = np.maximum(0.0, cdist(det_features, det_features, metric))
     if leg1 != 0:
@@ -165,8 +165,8 @@ def vis_id_feature_A_distance(tracks, detections, metric='cosine'):
     if leg2 > 10:
         leg2 = 10
         detections = detections[:10]
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     return track_features, det_features, cost_matrix, cost_matrix_det, cost_matrix_track
 
 def gate_cost_matrix(kf, cost_matrix, tracks, detections, only_position=False):

--- a/tutorials/qdtrack/byte_tracker.py
+++ b/tutorials/qdtrack/byte_tracker.py
@@ -17,7 +17,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/qdtrack/mot_online/matching.py
+++ b/tutorials/qdtrack/mot_online/matching.py
@@ -69,13 +69,13 @@ def ious(atlbrs, btlbrs):
 
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=float)
     if ious.size == 0:
         return ious
 
     ious = bbox_ious(
-        np.ascontiguousarray(atlbrs, dtype=np.float),
-        np.ascontiguousarray(btlbrs, dtype=np.float)
+        np.ascontiguousarray(atlbrs, dtype=float),
+        np.ascontiguousarray(btlbrs, dtype=float)
     )
 
     return ious
@@ -109,13 +109,13 @@ def embedding_distance(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
     #for i, track in enumerate(tracks):
         #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     return cost_matrix
 
@@ -127,17 +127,17 @@ def embedding_distance2(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
     #for i, track in enumerate(tracks):
         #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
-    track_features = np.asarray([track.features[0] for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.features[0] for track in tracks], dtype=float)
     cost_matrix2 = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
-    track_features = np.asarray([track.features[len(track.features)-1] for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.features[len(track.features)-1] for track in tracks], dtype=float)
     cost_matrix3 = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     for row in range(len(cost_matrix)):
         cost_matrix[row] = (cost_matrix[row]+cost_matrix2[row]+cost_matrix3[row])/3
@@ -149,11 +149,11 @@ def vis_id_feature_A_distance(tracks, detections, metric='cosine'):
     det_features = []
     leg1 = len(tracks)
     leg2 = len(detections)
-    cost_matrix = np.zeros((leg1, leg2), dtype=np.float)
-    cost_matrix_det = np.zeros((leg1, leg2), dtype=np.float)
-    cost_matrix_track = np.zeros((leg1, leg2), dtype=np.float)
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    cost_matrix = np.zeros((leg1, leg2), dtype=float)
+    cost_matrix_det = np.zeros((leg1, leg2), dtype=float)
+    cost_matrix_track = np.zeros((leg1, leg2), dtype=float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     if leg2 != 0:
         cost_matrix_det = np.maximum(0.0, cdist(det_features, det_features, metric))
     if leg1 != 0:
@@ -167,8 +167,8 @@ def vis_id_feature_A_distance(tracks, detections, metric='cosine'):
     if leg2 > 10:
         leg2 = 10
         detections = detections[:10]
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     return track_features, det_features, cost_matrix, cost_matrix_det, cost_matrix_track
 
 def gate_cost_matrix(kf, cost_matrix, tracks, detections, only_position=False):

--- a/tutorials/qdtrack/tracker_reid_motion.py
+++ b/tutorials/qdtrack/tracker_reid_motion.py
@@ -17,7 +17,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score, temp_feat, buffer_size=30):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/trades/byte_tracker.py
+++ b/tutorials/trades/byte_tracker.py
@@ -16,7 +16,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/trades/mot_online/matching.py
+++ b/tutorials/trades/mot_online/matching.py
@@ -68,13 +68,13 @@ def ious(atlbrs, btlbrs):
     :type atlbrs: list[tlbr] | np.ndarray
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=float)
     if ious.size == 0:
         return ious
 
     ious = bbox_ious(
-        np.ascontiguousarray(atlbrs, dtype=np.float),
-        np.ascontiguousarray(btlbrs, dtype=np.float)
+        np.ascontiguousarray(atlbrs, dtype=float),
+        np.ascontiguousarray(btlbrs, dtype=float)
     )
 
     return ious
@@ -107,13 +107,13 @@ def embedding_distance(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
     #for i, track in enumerate(tracks):
         #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     return cost_matrix
 
@@ -125,17 +125,17 @@ def embedding_distance2(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
     #for i, track in enumerate(tracks):
         #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
-    track_features = np.asarray([track.features[0] for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.features[0] for track in tracks], dtype=float)
     cost_matrix2 = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
-    track_features = np.asarray([track.features[len(track.features)-1] for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.features[len(track.features)-1] for track in tracks], dtype=float)
     cost_matrix3 = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     for row in range(len(cost_matrix)):
         cost_matrix[row] = (cost_matrix[row]+cost_matrix2[row]+cost_matrix3[row])/3
@@ -147,11 +147,11 @@ def vis_id_feature_A_distance(tracks, detections, metric='cosine'):
     det_features = []
     leg1 = len(tracks)
     leg2 = len(detections)
-    cost_matrix = np.zeros((leg1, leg2), dtype=np.float)
-    cost_matrix_det = np.zeros((leg1, leg2), dtype=np.float)
-    cost_matrix_track = np.zeros((leg1, leg2), dtype=np.float)
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    cost_matrix = np.zeros((leg1, leg2), dtype=float)
+    cost_matrix_det = np.zeros((leg1, leg2), dtype=float)
+    cost_matrix_track = np.zeros((leg1, leg2), dtype=float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     if leg2 != 0:
         cost_matrix_det = np.maximum(0.0, cdist(det_features, det_features, metric))
     if leg1 != 0:
@@ -165,8 +165,8 @@ def vis_id_feature_A_distance(tracks, detections, metric='cosine'):
     if leg2 > 10:
         leg2 = 10
         detections = detections[:10]
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     return track_features, det_features, cost_matrix, cost_matrix_det, cost_matrix_track
 
 def gate_cost_matrix(kf, cost_matrix, tracks, detections, only_position=False):

--- a/tutorials/trades/tracker.py
+++ b/tutorials/trades/tracker.py
@@ -272,7 +272,7 @@ class Tracker(object):
         """
         n_ = boxes.shape[0]
         k_ = query_boxes.shape[0]
-        overlaps = np.zeros((n_, k_), dtype=np.float)
+        overlaps = np.zeros((n_, k_), dtype=float)
         for k in range(k_):
             query_box_area = (query_boxes[k, 2] - query_boxes[k, 0] + 1) * (query_boxes[k, 3] - query_boxes[k, 1] + 1)
             for n in range(n_):

--- a/tutorials/trades/tracker.py
+++ b/tutorials/trades/tracker.py
@@ -25,15 +25,15 @@ class Tracker(object):
                 self.tracks.append(item)
                 self.nID = 10000
                 self.embedding_bank = np.zeros((self.nID, 128))
-                self.cat_bank = np.zeros((self.nID), dtype=np.int)
+                self.cat_bank = np.zeros((self.nID), dtype=int)
 
     def reset(self):
         self.id_count = 0
         self.nID = 10000
         self.tracks = []
         self.embedding_bank = np.zeros((self.nID, 128))
-        self.cat_bank = np.zeros((self.nID), dtype=np.int)
-        self.tracklet_ages = np.zeros((self.nID), dtype=np.int)
+        self.cat_bank = np.zeros((self.nID), dtype=int)
+        self.tracklet_ages = np.zeros((self.nID), dtype=int)
         self.alive = []
 
     def step(self, results_with_low, public_det=None):
@@ -253,7 +253,7 @@ class Tracker(object):
         a = feat[None, :]
         b = self.embedding_bank[:nID, :]
         if len(b) > 0:
-            alive = np.array(self.alive, dtype=np.int) - 1
+            alive = np.array(self.alive, dtype=int) - 1
             cosim = cosine(a, b)
             cosim = np.reshape(cosim, newshape=(-1))
             cosim[alive] = -2

--- a/tutorials/transtrack/mot_online/byte_tracker.py
+++ b/tutorials/transtrack/mot_online/byte_tracker.py
@@ -15,7 +15,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score, buffer_size=30):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/tutorials/transtrack/mot_online/matching.py
+++ b/tutorials/transtrack/mot_online/matching.py
@@ -58,13 +58,13 @@ def ious(atlbrs, btlbrs):
 
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=float)
     if ious.size == 0:
         return ious
 
     ious = bbox_ious(
-        np.ascontiguousarray(atlbrs, dtype=np.float),
-        np.ascontiguousarray(btlbrs, dtype=np.float)
+        np.ascontiguousarray(atlbrs, dtype=float),
+        np.ascontiguousarray(btlbrs, dtype=float)
     )
 
     return ious
@@ -98,11 +98,11 @@ def embedding_distance(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     return cost_matrix
 

--- a/yolox/deepsort_tracker/deepsort.py
+++ b/yolox/deepsort_tracker/deepsort.py
@@ -206,7 +206,7 @@ class DeepSort(object):
             x1, y1, x2, y2 = self._tlwh_to_xyxy_noclip(box)
             track_id = track.track_id
             class_id = track.class_id
-            outputs.append(np.array([x1, y1, x2, y2, track_id, class_id], dtype=np.int))
+            outputs.append(np.array([x1, y1, x2, y2, track_id, class_id], dtype=int))
         if len(outputs) > 0:
             outputs = np.stack(outputs, axis=0)
         return outputs

--- a/yolox/deepsort_tracker/detection.py
+++ b/yolox/deepsort_tracker/detection.py
@@ -24,7 +24,7 @@ class Detection(object):
     """
 
     def __init__(self, tlwh, confidence, feature):
-        self.tlwh = np.asarray(tlwh, dtype=np.float)
+        self.tlwh = np.asarray(tlwh, dtype=float)
         self.confidence = float(confidence)
         self.feature = np.asarray(feature, dtype=np.float32)
 

--- a/yolox/motdt_tracker/matching.py
+++ b/yolox/motdt_tracker/matching.py
@@ -39,13 +39,13 @@ def ious(atlbrs, btlbrs):
     :type atlbrs: list[tlbr] | np.ndarray
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=float)
     if ious.size == 0:
         return ious
 
     ious = bbox_ious(
-        np.ascontiguousarray(atlbrs, dtype=np.float),
-        np.ascontiguousarray(btlbrs, dtype=np.float)
+        np.ascontiguousarray(atlbrs, dtype=float),
+        np.ascontiguousarray(btlbrs, dtype=float)
     )
 
     return ious
@@ -73,7 +73,7 @@ def nearest_reid_distance(tracks, detections, metric='cosine'):
     :type detections: list[BaseTrack]
     :rtype cost_matrix np.ndarray
     """
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
 
@@ -92,7 +92,7 @@ def mean_reid_distance(tracks, detections, metric='cosine'):
     :type metric: str
     :rtype cost_matrix np.ndarray
     """
-    cost_matrix = np.empty((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.empty((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
 

--- a/yolox/motdt_tracker/motdt_tracker.py
+++ b/yolox/motdt_tracker/motdt_tracker.py
@@ -21,7 +21,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score, max_n_features=100, from_det=True):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/yolox/motdt_tracker/motdt_tracker.py
+++ b/yolox/motdt_tracker/motdt_tracker.py
@@ -248,7 +248,7 @@ class OnlineTracker(object):
             0.7,
             )
             keep = nms_out_index.numpy()
-            mask = np.zeros(len(rois), dtype=np.bool)
+            mask = np.zeros(len(rois), dtype=bool)
             mask[keep] = True
             keep = np.where(mask & (scores >= self.min_cls_score))[0]
             detections = [detections[i] for i in keep]

--- a/yolox/motdt_tracker/reid_model.py
+++ b/yolox/motdt_tracker/reid_model.py
@@ -60,7 +60,7 @@ def load_net(fname, net, prefix='', load_state_dict=False):
                 lr = h5f.attrs['learning_rates']
             else:
                 lr = h5f.attrs.get('lr', -1)
-                lr = np.asarray([lr] if lr > 0 else [], dtype=np.float)
+                lr = np.asarray([lr] if lr > 0 else [], dtype=float)
 
             return epoch, lr
 

--- a/yolox/tracker/byte_tracker.py
+++ b/yolox/tracker/byte_tracker.py
@@ -15,7 +15,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/yolox/tracker/matching.py
+++ b/yolox/tracker/matching.py
@@ -58,13 +58,13 @@ def ious(atlbrs, btlbrs):
 
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=float)
     if ious.size == 0:
         return ious
 
     ious = bbox_ious(
-        np.ascontiguousarray(atlbrs, dtype=np.float),
-        np.ascontiguousarray(btlbrs, dtype=np.float)
+        np.ascontiguousarray(atlbrs, dtype=float),
+        np.ascontiguousarray(btlbrs, dtype=float)
     )
 
     return ious
@@ -118,13 +118,13 @@ def embedding_distance(tracks, detections, metric='cosine'):
     :return: cost_matrix np.ndarray
     """
 
-    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=np.float)
+    cost_matrix = np.zeros((len(tracks), len(detections)), dtype=float)
     if cost_matrix.size == 0:
         return cost_matrix
-    det_features = np.asarray([track.curr_feat for track in detections], dtype=np.float)
+    det_features = np.asarray([track.curr_feat for track in detections], dtype=float)
     #for i, track in enumerate(tracks):
         #cost_matrix[i, :] = np.maximum(0.0, cdist(track.smooth_feat.reshape(1,-1), det_features, metric))
-    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=np.float)
+    track_features = np.asarray([track.smooth_feat for track in tracks], dtype=float)
     cost_matrix = np.maximum(0.0, cdist(track_features, det_features, metric))  # Nomalized features
     return cost_matrix
 


### PR DESCRIPTION
See [deprecated type aliases](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)

I chose to use base types instead of using the renamed aliases in order to stay compatible with older numpy and python versions:

np.float -> float
np.int -> int
np.bool -> bool

These numpy types were simply aliases of the base python types.

Explicitly sized types like float32 and float64 were left alone.