### PR TITLE
fix: onnx failing install in newer python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ opencv_python
 loguru
 scikit-image
 tqdm
-torchvision>=0.10.0
 Pillow
 thop
 ninja
@@ -15,8 +14,9 @@ lap
 motmetrics
 filterpy
 h5py
+onnx
+onnxruntime
+onnx-simplifier
 
 # verified versions
-onnx==1.8.1
-onnxruntime==1.8.0
-onnx-simplifier==0.3.5
+torchvision>=0.10.0


### PR DESCRIPTION
Hello,

I am trying to run [this demo that uses your lib](https://github.com/roboflow/notebooks/blob/main/notebooks/how-to-track-football-players.ipynb), but found that the onnx versions provided in the `requirements.txt` are not compatible with the newer python versions used by google colab.

In my environment I fixed this by creating the following function:
```python
def replaceVersionedLibraryForGenericVersion(requirementsFilePath, libraryName) -> None:
  requirementsFile = open(requirementsFilePath, "r")
  editedRequirementsText = []
  libCheckString = libraryName + "=="
  for line in requirementsFile:
    if libCheckString in line:
      editedRequirementsText.append(libraryName + "\n")
    else:
      editedRequirementsText.append(line)
  requirementsFile.close()
  newRequirementsFile = open(requirementsFilePath, "w")
  newRequirementsFile.writelines(editedRequirementsText)
  newRequirementsFile.close()
```

And calling it like this right after cloning the repo:
```python
replaceVersionedLibraryForGenericVersion("ByteTrack/requirements.txt", "onnx")
replaceVersionedLibraryForGenericVersion("ByteTrack/requirements.txt", "onnxruntime")
```

This fixed my issue, but any other users of this lib will face the same issue. Since the onnx versions required are not fully compatible anymore, I suggest using the most recent versions to avoid this issue.