### PR TITLE
Update byte_tracker.py

### DIFF
--- a/yolox/tracker/byte_tracker.py
+++ b/yolox/tracker/byte_tracker.py
@@ -15,7 +15,7 @@ class STrack(BaseTrack):
     def __init__(self, tlwh, score):
 
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False


### PR DESCRIPTION
'np.float' was a deprecated alias for the builtin `float` and has been deprecated.