### PR TITLE
Fixed the Error while installing onnxruntime==1.8.0 onnxruntime=1.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ h5py
 
 # verified versions
 onnx==1.8.1
-onnxruntime==1.8.0
+onnxruntime>=1.20.0
 onnx-simplifier==0.3.5


### PR DESCRIPTION
This error occurs for the ones who has newer versions of python installed in there system.